### PR TITLE
[RFC]docker daemon ssl files now stays in redis

### DIFF
--- a/eru/api/container.py
+++ b/eru/api/container.py
@@ -1,18 +1,18 @@
 # coding: utf-8
-
 import logging
-from netaddr import IPAddress
-from flask import request, abort
 
-from eru.ipam import ipam
-from eru.async import dockerjob
-from eru.consts import ERU_AGENT_DIE_REASON
-from eru.clients import rds
-from eru.models.container import Container, check_eip_bound
-from eru.utils.decorator import check_request_json
-from eru.helpers.network import rebind_container_ip, bind_container_ip
+from flask import request, abort
+from netaddr import IPAddress
 
 from .bp import create_api_blueprint, DEFAULT_RETURN_VALUE
+from eru.async import dockerjob
+from eru.consts import ERU_AGENT_DIE_REASON
+from eru.helpers.network import rebind_container_ip, bind_container_ip
+from eru.ipam import ipam
+from eru.models.container import Container, check_eip_bound
+from eru.redis_client import rds
+from eru.utils.decorator import check_request_json
+
 
 bp = create_api_blueprint('container', __name__, url_prefix='/api/container')
 _log = logging.getLogger(__name__)

--- a/eru/api/deploy.py
+++ b/eru/api/deploy.py
@@ -1,28 +1,26 @@
 # coding:utf-8
-
-import os
-import logging
-import tempfile
 import itertools
+import logging
+import os
+import tempfile
 
 from flask import abort, request
 from werkzeug import secure_filename
 
-from eru.consts import TASK_BUILD, TASK_REMOVE, TASK_CREATE
-from eru.utils import is_strict_url
-from eru.utils.decorator import check_request_json
-
-from eru.ipam import ipam
-from eru.clients import rds
-from eru.models import App, Pod, Task, Container, Host
+from .bp import create_api_blueprint
 from eru.async.task import (
     create_containers_with_macvlan,
     build_docker_image,
     remove_containers,
 )
+from eru.consts import TASK_BUILD, TASK_REMOVE, TASK_CREATE
 from eru.helpers.scheduler import average_schedule, centralized_schedule
+from eru.ipam import ipam
+from eru.models import App, Pod, Task, Container, Host
+from eru.redis_client import rds
+from eru.utils import is_strict_url
+from eru.utils.decorator import check_request_json
 
-from .bp import create_api_blueprint
 
 bp = create_api_blueprint('deploy', __name__, url_prefix='/api/deploy')
 _log = logging.getLogger(__name__)

--- a/eru/api/host.py
+++ b/eru/api/host.py
@@ -1,15 +1,15 @@
 # coding: utf-8
-
 import logging
+
 from flask import abort, g, request
 
+from .bp import create_api_blueprint, DEFAULT_RETURN_VALUE
+from eru.docker_client import get_docker_client
+from eru.helpers.docker import save_docker_certs
 from eru.ipam import ipam
 from eru.models import Pod, Host, VLanGateway
 from eru.models.container import check_eip_bound
-from eru.clients import get_docker_client
-from eru.helpers.docker import save_docker_certs
 
-from .bp import create_api_blueprint, DEFAULT_RETURN_VALUE
 
 bp = create_api_blueprint('host', __name__, url_prefix='/api/host')
 _log = logging.getLogger(__name__)
@@ -31,23 +31,21 @@ def get_host(id_or_name):
 def create_host():
     """为了文件, 只好不用json了"""
     addr = request.form.get('addr', default='')
+    ip = addr.split(':', 1)[0]
     podname = request.form.get('podname', default='')
+    is_public = request.form.get('is_public', default=False, type=bool)
     if not (addr and podname):
-        abort(400, 'Need addr and podname')
+        abort(400, 'Bad addr or podname: addr="{}", podname="{}"'.format(addr, podname))
 
     pod = Pod.get_by_name(podname)
     if not pod:
-        abort(400, 'No pod found')
+        abort(400, 'Pod {} not found'.format(podname))
 
     # 存证书, 没有就算了
-    if all(k in request.files for k in ['ca', 'cert', 'key']):
-        try:
-            ca, cert, key = request.files['ca'], request.files['cert'], request.files['key']
-            save_docker_certs(addr.split(':', 1)[0], ca.read(), cert.read(), key.read())
-        finally:
-            ca.close()
-            cert.close()
-            key.close()
+    certs = ['ca', 'cert', 'key']
+    if all(k in request.files for k in certs):
+        certs_contents = tuple(request.files[f].read() for f in certs)
+        save_docker_certs(ip, *certs_contents)
 
     try:
         client = get_docker_client(addr, force_flush=True)
@@ -55,21 +53,19 @@ def create_host():
     except Exception as e:
         abort(400, 'Docker daemon error on host %s, error: %s' % (addr, e.message))
 
-    if not Host.create(pod, addr, info['Name'], info['ID'], info['NCPU'], info['MemTotal']):
+    if not Host.create(pod, addr, info['Name'], info['ID'], info['NCPU'],
+                       info['MemTotal'], is_public=is_public):
         abort(400, 'Error while creating host')
+
     return 201, DEFAULT_RETURN_VALUE
 
 
 @bp.route('/<id_or_name>/certs/', methods=['PUT'])
 def put_host_certs(id_or_name):
     host = _get_host(id_or_name)
-    ca, cert, key = request.files['ca'], request.files['cert'], request.files['key']
-    try:
-        save_docker_certs(host, ca.read(), cert.read(), key.read())
-    finally:
-        ca.close()
-        cert.close()
-        key.close()
+    certs = ['ca', 'cert', 'key']
+    certs_contents = tuple(request.files[f].read() for f in certs)
+    save_docker_certs(host.ip, *certs_contents)
     return DEFAULT_RETURN_VALUE
 
 

--- a/eru/api/task.py
+++ b/eru/api/task.py
@@ -1,10 +1,12 @@
 # coding: utf-8
-
 import json
+
 from flask import abort
-from eru.models import Task
-from eru.clients import rds
+
 from .bp import create_api_blueprint
+from eru.models import Task
+from eru.redis_client import rds
+
 
 bp = create_api_blueprint('task', __name__, url_prefix='/api/task')
 

--- a/eru/api/websockets.py
+++ b/eru/api/websockets.py
@@ -1,13 +1,15 @@
 # coding: utf-8
-
 import logging
+
 import geventwebsocket
+from eru.docker_client import get_docker_client
 from flask import Blueprint, request
 
 from eru import consts
-from eru.clients import rds, get_docker_client
 from eru.models import Task, Container
+from eru.redis_client import rds
 from eru.utils.notify import TaskNotifier
+
 
 bp = Blueprint('websockets', __name__, url_prefix='/websockets')
 _log = logging.getLogger(__name__)

--- a/eru/async/dockerjob.py
+++ b/eru/async/dockerjob.py
@@ -12,7 +12,7 @@ from werkzeug.security import gen_salt
 from docker.utils import LogConfig, Ulimit
 
 from eru import config
-from eru.clients import get_docker_client
+from eru.docker_client import get_docker_client
 from eru.templates import template
 from eru.async.utils import replace_ports
 from eru.utils.ensure import ensure_dir_absent, ensure_file

--- a/eru/async/task.py
+++ b/eru/async/task.py
@@ -1,21 +1,21 @@
 # coding:utf-8
-
 import json
-import time
 import logging
-from more_itertools import chunked
+import time
 from itertools import izip_longest
+
 from celery import current_app
+from more_itertools import chunked
 
 from eru import consts
 from eru.async import dockerjob
 from eru.config import DOCKER_REGISTRY
-from eru.clients import rds
-from eru.ipam import ipam
-from eru.utils.notify import TaskNotifier
-from eru.models import Container, Task, Image
-
 from eru.helpers.check import wait_health_check
+from eru.ipam import ipam
+from eru.models import Container, Task, Image
+from eru.redis_client import rds
+from eru.utils.notify import TaskNotifier
+
 
 _log = logging.getLogger(__name__)
 

--- a/eru/docker_client.py
+++ b/eru/docker_client.py
@@ -1,7 +1,6 @@
 # coding: utf-8
-
 import os
-import redis
+
 import docker
 from docker.tls import TLSConfig
 
@@ -11,11 +10,8 @@ from eru.config import (
     DOCKER_REGISTRY_EMAIL,
     DOCKER_REGISTRY_USERNAME,
     DOCKER_REGISTRY_PASSWORD,
-    REDIS_HOST,
-    REDIS_PORT,
-    REDIS_POOL_SIZE,
 )
-from eru.storage.redis import RedisStorage
+
 
 _docker_clients = {}
 
@@ -55,10 +51,3 @@ def get_docker_client(addr, force_flush=False):
         )
     _docker_clients[addr] = client
     return client
-
-def get_redis_client(host, port , max_connections):
-    pool = redis.ConnectionPool(host=host, port=port, max_connections=max_connections)
-    return redis.Redis(connection_pool=pool)
-
-rds = get_redis_client(REDIS_HOST, REDIS_PORT, REDIS_POOL_SIZE)
-config_backend = RedisStorage(rds)

--- a/eru/helpers/docker.py
+++ b/eru/helpers/docker.py
@@ -1,15 +1,79 @@
+import logging
 import os
 
-from eru.utils.ensure import ensure_file, ensure_dir
 from eru.config import DOCKER_CERT_PATH
+from eru.redis_client import rds
+from eru.utils.ensure import ensure_file, ensure_dir
 
-def save_docker_certs(host_or_ip, ca, cert, key):
+
+_log = logging.getLogger(__name__)
+needed_cert_files = ('ca.pem', 'cert.pem', 'key.pem')
+
+
+def save_docker_certs(ip, *certs):
+    """
+    save certs in DOCKER_CERT_PATH/{ip} as well as redis
+    :param ip: str, host ip address
+    :param certs: tuple of str, content of .pem files, must be (ca, cert, key)
+    """
     if not DOCKER_CERT_PATH:
+        _log.warn('DOCKER_CERT_PATH not set')
         return
-    if not isinstance(host_or_ip, basestring):
-        host_or_ip = host_or_ip.ip
-    base_dir = os.path.join(DOCKER_CERT_PATH, host_or_ip)
-    ensure_dir(base_dir)
-    ensure_file(os.path.join(base_dir, 'ca.pem'), mode=0444, content=ca)
-    ensure_file(os.path.join(base_dir, 'cert.pem'), mode=0444, content=cert)
-    ensure_file(os.path.join(base_dir, 'key.pem'), mode=0400, content=key)
+    certs_dir = make_certs_dir(ip)
+    for fname, content in zip(needed_cert_files, certs):
+        key = make_redis_cert_file_key(ip, fname)
+        rds.set(key, content)
+        ensure_file(os.path.join(certs_dir, fname), mode=0444, content=content)
+
+
+def get_docker_certs(ip):
+    """
+    return valid .cert absolute file paths: (ca_path, cert_path, key_path)
+    """
+    results = []
+    # make sure the directory for the cert files is created
+    make_certs_dir(ip)
+    for fname in needed_cert_files:
+        file_path = make_cert_path(ip, fname)
+        if not os.path.isfile(file_path):
+            dump_redis_cert_file(ip, fname, file_path)
+
+        results.append(file_path)
+
+    return results
+
+
+def dump_redis_cert_file(ip, file_name, dump_location):
+    """
+    get .pem file from redis, put in dump_location
+    :param ip: str, {ip}:{port}
+    :param file_name: str, choose from ['ca.pem', 'cert.pem', 'key.pem']
+    """
+    key = make_redis_cert_file_key(ip, file_name)
+    cert_content = rds.get(key)
+    if not cert_content:
+        raise Exception('missing {} in redis!'.format(key))
+    with open(dump_location, 'w') as f:
+        f.write(cert_content)
+
+
+def make_cert_path(ip, file_name):
+    """
+    make up the local path for the given .pem file according to DOCKER_CERT_PATH
+    :param ip: str, {ip}:{port}, could be a single ip as well
+    :param file_name: str, choose from ['ca.pem', 'cert.pem', 'key.pem']
+    """
+    ip = ip.split(':', 1)[0]
+    cert_folder = os.path.join(DOCKER_CERT_PATH, ip)
+    path = os.path.join(cert_folder, file_name)
+    return path
+
+
+def make_redis_cert_file_key(ip, file_name):
+    return 'cert_file_{}_{}'.format(ip, file_name)
+
+
+def make_certs_dir(ip):
+    certs_dir = os.path.join(DOCKER_CERT_PATH, ip)
+    ensure_dir(certs_dir)
+    return certs_dir

--- a/eru/ipam/calico.py
+++ b/eru/ipam/calico.py
@@ -1,18 +1,18 @@
 # coding: utf-8
-
-import os
 import logging
+import os
+
 from netaddr import IPAddress, IPNetwork, AddrFormatError
-from pycalico.ipam import IPAMClient
 from pycalico.datastore import ETCD_SCHEME_ENV, ETCD_AUTHORITY_ENV, Rule
 from pycalico.datastore_datatypes import IPPool
+from pycalico.ipam import IPAMClient
 
 from eru.agent import get_agent
-from eru.clients import rds
 from eru.config import ETCD
 from eru.ipam.base import BaseIPAM
 from eru.ipam.structure import WrappedIP, WrappedNetwork
 from eru.models.eip_pool import eip_pool
+from eru.redis_client import rds
 
 
 def _get_client():

--- a/eru/models/appconfig.py
+++ b/eru/models/appconfig.py
@@ -1,9 +1,9 @@
 # coding: utf-8
-
 import yaml
 from netaddr import IPAddress, AddrFormatError
 
-from eru.clients import config_backend
+from eru.redis_client import config_backend
+
 
 __all__ = ['AppConfig', 'ResourceConfig', 'verify_appconfig', ]
 

--- a/eru/models/base.py
+++ b/eru/models/base.py
@@ -1,11 +1,11 @@
 # coding: utf-8
-
 import json
+
 from sqlalchemy.ext.declarative import declared_attr
 
-from eru.utils import Jsonized
 from eru.models import db
-from eru.clients import rds
+from eru.redis_client import rds
+from eru.utils import Jsonized
 
 
 class Base(Jsonized, db.Model):

--- a/eru/models/container.py
+++ b/eru/models/container.py
@@ -1,19 +1,20 @@
 # coding:utf-8
-
-import json
 import cPickle
-import requests
 import itertools
-import sqlalchemy.exc
-from decimal import Decimal as D
+import json
 from datetime import datetime
+from decimal import Decimal as D
 
-from eru.ipam import ipam
+import requests
+import sqlalchemy.exc
+
 from eru.agent import get_agent
-from eru.clients import rds
+from eru.ipam import ipam
 from eru.models import db
 from eru.models.base import Base, PropsMixin, PropsItem
+from eru.redis_client import rds
 from eru.utils.decorator import EruJSONEncoder
+
 
 _CONTAINER_PUB_KEY = 'container:%s'
 _EIP_BOUND_KEY = 'eip:%s:container'

--- a/eru/models/eip_pool.py
+++ b/eru/models/eip_pool.py
@@ -1,12 +1,12 @@
 # coding: utf-8
-
 from netaddr import IPAddress
-from eru.clients import rds
+
+from eru.redis_client import rds
 
 
 class EIPPool(object):
 
-    EIP_POOL_KEY = 'eru:eip:pool' 
+    EIP_POOL_KEY = 'eru:eip:pool'
 
     def add_eip(self, *eips):
         rds.sadd(self.EIP_POOL_KEY, *[eip.value for eip in eips])

--- a/eru/models/network.py
+++ b/eru/models/network.py
@@ -1,13 +1,13 @@
 # coding: utf-8
-
 import more_itertools
 import sqlalchemy.exc
 from netaddr import IPAddress, IPNetwork, AddrFormatError
 
-from eru.clients import rds
 from eru.models import db
 from eru.models.base import Base
+from eru.redis_client import rds
 from eru.utils.decorator import redis_lock
+
 
 class IPMixin(object):
 

--- a/eru/redis_client.py
+++ b/eru/redis_client.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+import redis
+
+from eru.config import REDIS_HOST, REDIS_PORT, REDIS_POOL_SIZE
+from eru.storage.redis import RedisStorage
+
+
+def get_redis_client(host, port , max_connections):
+    pool = redis.ConnectionPool(host=host, port=port, max_connections=max_connections)
+    return redis.Redis(connection_pool=pool)
+
+
+rds = get_redis_client(REDIS_HOST, REDIS_PORT, REDIS_POOL_SIZE)
+config_backend = RedisStorage(rds)

--- a/eru/storage/redis.py
+++ b/eru/storage/redis.py
@@ -1,6 +1,6 @@
 # coding: utf-8
-
 from eru.storage.base import BaseConfigStorage
+
 
 class RedisStorage(BaseConfigStorage):
 

--- a/eru/utils/decorator.py
+++ b/eru/utils/decorator.py
@@ -1,15 +1,15 @@
 # coding: utf-8
-
-import json
-import inspect
 import functools
-
-from flask import request, Response, abort
+import inspect
+import json
 from datetime import datetime
 from decimal import Decimal
 
-from eru.clients import rds
+from flask import request, Response, abort
+
+from eru.redis_client import rds
 from eru.utils import Jsonized
+
 
 def redis_lock(fmt):
     def _redis_lock(f):

--- a/eru/utils/notify.py
+++ b/eru/utils/notify.py
@@ -1,6 +1,5 @@
 # coding:utf-8
-
-from eru.clients import rds
+from eru.agent import get_agent
 from eru.consts import (
     ERU_TASK_PUBKEY,
     ERU_TASK_LOGKEY,
@@ -9,7 +8,8 @@ from eru.consts import (
     TASK_RESULT_FAILED,
     PUB_END_MESSAGE,
 )
-from eru.agent import get_agent
+from eru.redis_client import rds
+
 
 class TaskNotifier(object):
 

--- a/scripts/clean_image.py
+++ b/scripts/clean_image.py
@@ -5,7 +5,7 @@ from functools import wraps
 from eru.app import create_app_with_celery
 from eru.models import Host
 from eru.config import DOCKER_REGISTRY
-from eru.clients import get_docker_client
+from eru.docker_client import get_docker_client
 
 
 def with_app_context(f):

--- a/scripts/fix_core.py
+++ b/scripts/fix_core.py
@@ -1,11 +1,10 @@
 # coding: utf-8
-
 from functools import wraps
 
-from eru.clients import rds
 from eru.app import create_app_with_celery
 from eru.models import Host, Container
 from eru.models.host import _create_cores_on_host
+from eru.redis_client import rds
 
 
 def with_app_context(f):

--- a/scripts/fix_ip.py
+++ b/scripts/fix_ip.py
@@ -1,11 +1,11 @@
 # coding: utf-8
-
-import more_itertools
 from functools import wraps
 
-from eru.clients import rds
+import more_itertools
+
 from eru.app import create_app_with_celery
 from eru.models import Network
+from eru.redis_client import rds
 
 
 def with_app_context(f):

--- a/scripts/get_gateway.py
+++ b/scripts/get_gateway.py
@@ -1,12 +1,12 @@
 # coding: utf-8
-
 import sys
 from functools import wraps
+
 from netaddr import IPAddress
 
-from eru.clients import rds
 from eru.app import create_app_with_celery
 from eru.models import Network, VLanGateway, Host
+from eru.redis_client import rds
 
 
 def with_app_context(f):

--- a/scripts/rebuild_container_pool_for_agent.py
+++ b/scripts/rebuild_container_pool_for_agent.py
@@ -1,11 +1,10 @@
 # coding: utf-8
-
 from functools import wraps
 
 from eru.app import create_app_with_celery
-from eru.clients import rds
-from eru.models import Host
 from eru.async.task import add_container_for_agent
+from eru.models import Host
+from eru.redis_client import rds
 
 
 def with_app_context(f):

--- a/shell.py
+++ b/shell.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # coding: utf-8
-
+import atexit
 import os
 import sys
-import atexit
+
 import IPython
 
 from eru.app import create_app_with_celery
+
 
 def hook_readline_hist():
     try:
@@ -43,7 +44,8 @@ def pre_imports():
     from eru.models.task import Task
     from eru.models.network import Network, IP
     from eru.models import db
-    from eru.clients import rds, get_docker_client
+    from eru.docker_client import get_docker_client
+    from eru.redis_client import rds
     return locals()
 
 def ipython_shell(user_ns):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,9 @@
 # coding: utf-8
-
 import pytest
 
 from eru.app import create_app_with_celery
-from eru.clients import rds
 from eru.models import db
+from eru.redis_client import rds
 
 
 @pytest.fixture


### PR DESCRIPTION
* eru-core is more possible to horizontal scaling because:
	* when save_docker_certs is called, also save in eru-core redis
	* when initialize a TLSConfig instance, dump certificate files from redis to local storage


* Host can be set public during initialization.
* moves all redis singletons from eru.clients to eru.redis_client, and docker in eru.docker_client
* PEP8 format imports on all touched python code

不小心把之前的坏习惯带过来了。。。一个commit压了太多改动，很难阅读，抱歉。。

P.S.

* import部分的改动基本都是PEP8的自动格式化：自带库放一起，三方库放一起，项目引用的库放一起