### PR TITLE
ensure certificate files' existence in redis when get_docker_client

### DIFF
--- a/eru/helpers/docker.py
+++ b/eru/helpers/docker.py
@@ -28,33 +28,27 @@ def save_docker_certs(ip, *certs):
 
 def get_docker_certs(ip):
     """
-    return valid .cert absolute file paths: (ca_path, cert_path, key_path)
+    return valid .cert absolute file paths: (ca_path, cert_path, key_path), in
+    the mean time, ensure the files are on both local and redis
     """
     results = []
     # make sure the directory for the cert files is created
     make_certs_dir(ip)
     for fname in needed_cert_files:
         file_path = make_cert_path(ip, fname)
-        if not os.path.isfile(file_path):
-            dump_redis_cert_file(ip, fname, file_path)
+        key = make_redis_cert_file_key(ip, fname)
+        if key in rds:
+            # respect redis file first, if not found, provide with local copy,
+            # this could make things easier when changing certificate files
+            content = rds.get(key)
+            ensure_file(file_path, mode=0444, content=content)
+        else:
+            with open(file_path) as f:
+                rds.set(key, f.read())
 
         results.append(file_path)
 
     return results
-
-
-def dump_redis_cert_file(ip, file_name, dump_location):
-    """
-    get .pem file from redis, put in dump_location
-    :param ip: str, {ip}:{port}
-    :param file_name: str, choose from ['ca.pem', 'cert.pem', 'key.pem']
-    """
-    key = make_redis_cert_file_key(ip, file_name)
-    cert_content = rds.get(key)
-    if not cert_content:
-        raise Exception('missing {} in redis!'.format(key))
-    with open(dump_location, 'w') as f:
-        f.write(cert_content)
 
 
 def make_cert_path(ip, file_name):

--- a/eru/utils/ensure.py
+++ b/eru/utils/ensure.py
@@ -84,4 +84,3 @@ def ensure_link(path, target, owner=None, group=None):
 
     if not os.path.lexists(path):
         os.symlink(target, path)
-


### PR DESCRIPTION
不知道为什么当时feature/cert合并的时候，get_docker_client没有用get_docker_certs这个方法，在这里一并改好 @tonicbupt 